### PR TITLE
 it will raise an error of below

### DIFF
--- a/vega/core/report/report.py
+++ b/vega/core/report/report.py
@@ -204,7 +204,7 @@ class Report(object):
                         _file_name = "performance_{}.json".format(worker_id)
                     _file = FileOps.join_path(_path, _file_name)
                     with open(_file, "w") as f:
-                        json.dump(value, f)
+                        json.dump(record_value, f)
             except Exception as ex:
                 logging.error("Failed to save {}, file={}, desc={}, msg={}".format(
                     record_name, _file, record_value, str(ex)))

--- a/vega/datasets/pytorch/auto_lane_datasets.py
+++ b/vega/datasets/pytorch/auto_lane_datasets.py
@@ -109,7 +109,7 @@ class AutoLaneDataset(Dataset):
         self.encode_lane = self.codec_obj.encode_lane
         read_funcs = dict(
             CULane=_read_culane_type_annot,
-            CurveLane=_read_culane_type_annot,
+            CurveLane=_read_curvelane_type_annot,
         )
         if self.args.dataset_format not in read_funcs:
             raise NotImplementedError(f'dataset_format should be one of {read_funcs.keys()}')


### PR DESCRIPTION
Failed to save desc, file=/home/mengzhibin/vega/tasks/1105.182606.151/workers/nas/4/desc_4.json, desc={'detector': {'name': 'AutoLaneDetector', 'modules': ['backbone', 'neck', 'head'], 'num_class': 2, 'method': 'random', 'code': 'x50(2x24d)_48_112111-211112-1-1+122-022', 'backbone': {'name': 'ResNeXtVariantDet', 'arch': '112111-211112-1-1', 'base_depth': 50, 'base_channel': 48, 'groups': 2, 'base_width': 24, 'num_stages': 4, 'strides': (1, 2, 2, 2), 'dilations': (1, 1, 1, 1), 'out_indices': (0, 1, 2, 3), 'frozen_stages': -1, 'zero_init_residual': False, 'norm_cfg': {'type': 'BN', 'requires_grad': True}, 'conv_cfg': {'type': 'Conv'}, 'out_channels': [384, 1536, 1536, 1536], 'style': 'pytorch'}, 'neck': {'arch_code': '122-022', 'name': 'FeatureFusionModule', 'in_channels': [384, 1536, 1536, 1536]}, 'head': {'base_channel': 1792, 'num_classes': 2, 'up_points': 73, 'down_points': 72, 'name': 'AutoLaneHead'}, 'limits': {'GFlops': 1}}, 'modules': ['detector']}, msg=local variable 'value' referenced before assignment Failed to save performance, file=/home/mengzhibin/vega/tasks/1105.182606.151/workers/nas/4/performance_4.json, desc={'LaneMetric': 0.0}, msg=local variable 'value' referenced before assignment