### PR TITLE
mindspore spnas revise

### DIFF
--- a/examples/nas/sp_nas/spnas_md.yml
+++ b/examples/nas/sp_nas/spnas_md.yml
@@ -1,3 +1,7 @@
+general:
+    backend: mindspore
+    device_category: NPU
+
 pipeline: [serial]
 
 serial:

--- a/vega/metrics/mindspore/__init__.py
+++ b/vega/metrics/mindspore/__init__.py
@@ -6,4 +6,5 @@ ClassFactory.lazy_register("vega.metrics.mindspore", {
     "segmentation_metric": ["trainer.metric:IoUMetric"],
     "classifier_metric": ["trainer.metric:accuracy"],
     "sr_metric": ["trainer.metric:PSNR", "trainer.metric:SSIM"],
+    "detection_metric": ["trainer.metric:CocoMetric", "trainer.metric:coco"],
 })

--- a/vega/metrics/mindspore/detection_metric.py
+++ b/vega/metrics/mindspore/detection_metric.py
@@ -1,0 +1,126 @@
+# -*- coding:utf-8 -*-
+
+# Copyright (C) 2020. Huawei Technologies Co., Ltd. All rights reserved.
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the MIT License.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# MIT License for more details.
+
+"""Metric of detection task by using coco tools."""
+import os
+import json
+from pycocotools.coco import COCO
+from pycocotools.cocoeval import COCOeval
+from vega.common import ClassFactory, ClassType
+from vega.metrics.mindspore.metrics import MetricBase
+from vega.common.task_ops import TaskOps
+
+
+@ClassFactory.register(ClassType.METRIC, alias='coco')
+class CocoMetric(MetricBase):
+    """Save and summary metric from mdc dataset using coco tools."""
+
+    __metric_name__ = "coco"
+
+    def __init__(self, anno_path=None, category=None):
+        self.anno_path = anno_path or os.path.join(TaskOps().local_output_path, 'instances.json')
+        self.category = category or []
+        self.result_record = []
+
+    @property
+    def objective(self):
+        """Define reward mode, default is max."""
+        return {'mAP': 'MAX', 'AP50': 'MAX', 'AP_small': 'MAX', 'AP_medium': 'MAX', 'AP_large': 'MAX'}
+
+    def __call__(self, output, targets, *args, **kwargs):
+        """Append input into result record cache.
+
+        :param output: output data
+        :param target: target data
+        :return:
+        """
+        if isinstance(output, dict):
+            return None
+        coco_results = []
+        for id, prediction in enumerate(output):
+            boxes = xyxy2xywh(prediction['boxes'])
+            scores = prediction["scores"].asnumpy().tolist()
+            labels = prediction["labels"].asnumpy().tolist()
+            img_id = targets[id]['image_id'].asnumpy().tolist()[0]
+            for idx, box in enumerate(boxes):
+                data = {}
+                data['image_id'] = img_id
+                data['bbox'] = box
+                data['score'] = scores[idx]
+                data['category_id'] = labels[idx]
+                coco_results.append(data)
+        self.result_record.extend(coco_results)
+        return None
+
+    def reset(self):
+        """Reset states for new evaluation after each epoch."""
+        self.result_record = []
+
+    def summary(self):
+        """Summary all record from result cache, and get performance."""
+        if not self.result_record:
+            return {"mAP": -1, "AP_small": -1, "AP_medium": -1, "AP_large": -1}
+        det_json_file = os.path.join(TaskOps().local_output_path, 'det_json_file.json')
+        with open(det_json_file, 'w') as f:
+            json.dump(self.result_record, f)
+        eval_result = self.print_scores(det_json_file, self.anno_path)
+        ap_result = eval_result.pop('AP(bbox)')
+        ap_result = list(ap_result)
+        ap_result = {
+            "mAP": ap_result[0] * 100,
+            "AP50": ap_result[1] * 100,
+            "AP_small": ap_result[3] * 100,
+            "AP_medium": ap_result[4] * 100,
+            "AP_large": ap_result[5] * 100
+        }
+        if eval_result:
+            ap_result.update(eval_result)
+        return ap_result
+
+    def print_scores(self, det_json_file, json_file):
+        """Print scores.
+
+        :param det_json_file: dest json file
+        :param json_file: gt json file
+        :return:
+        """
+        ret = {}
+        coco = COCO(json_file)
+        cocoDt = coco.loadRes(det_json_file)
+        cocoEval = COCOeval(coco, cocoDt, 'bbox')
+        cocoEval.evaluate()
+        cocoEval.accumulate()
+        cocoEval.summarize()
+        ret['AP(bbox)'] = cocoEval.stats
+        for id, item in enumerate(self.category):
+            cocoEval = COCOeval(coco, cocoDt, 'bbox')
+            cocoEval.params.catIds = [id + 1]
+            # cocoEval.params.iouThrs = [0.5]
+            cocoEval.evaluate()
+            cocoEval.accumulate()
+            cocoEval.summarize()
+            if len(cocoEval.stats) > 0:
+                ret[item] = cocoEval.stats[1] * 100
+        return ret
+
+
+def xyxy2xywh(boxes):
+    """Transform the bbox coordinate to [x,y ,w,h].
+
+    :param bbox: the predict bounding box coordinate
+    :type bbox: list
+    :return: [x,y ,w,h]
+    :rtype: list
+    """
+    from mindspore import ops
+    ms_unbind = ops.Unstack(axis=1)
+    ms_stack = ops.Stack(axis=1)
+    xmin, ymin, xmax, ymax = ms_unbind(boxes)
+    return ms_stack((xmin, ymin, xmax - xmin, ymax - ymin)).asnumpy().tolist()

--- a/vega/metrics/mindspore/metrics.py
+++ b/vega/metrics/mindspore/metrics.py
@@ -73,9 +73,9 @@ class Metrics(object):
         """Calculate all supported metrics by using output and target.
 
         :param output: predicted output by networks
-        :type output: torch tensor
+        :type output: mindspore tensor
         :param target: target label data
-        :type target: torch tensor
+        :type target: mindspore tensor
         :return: performance of metrics
         :rtype: list
         """
@@ -105,4 +105,8 @@ class Metrics(object):
         :type metrics: dict
         """
         for key in metrics:
-            self.metric_results[key] = metrics[key]
+            if not isinstance(metrics[key], (int, float)):
+                value = metrics[key].item()
+            else:
+                value = metrics[key]
+            self.metric_results[key] = value


### PR DESCRIPTION
### 配置信息
```
显卡：Ascend 910B
架构：aarch64
框架：mindspore 1.3.0
算法：SPNAS
CANN包：ascend-toolkit 5.0.2
版本：vega 1.7.1
模式：GRAPH_MODE
```

### 1. spnas_md.yml 文件修改
修改原因：vega.run() 会根据配置文件调用 _init_env() 函数初始化后台环境，通过yml文件指定 backend 以及device 

### 2. vega/algorithms/nas/sp_nas/spnas_trainer_callback.py 文件修改
#### line 140 
修改原因：
![trainer_bug](https://user-images.githubusercontent.com/61997321/140016320-38742472-ae21-4793-9c34-5fd68f2d0657.png)
#### line 152
修改原因：
![ann_file_bug](https://user-images.githubusercontent.com/61997321/140016319-ce0b2cd7-71c2-465c-98cf-91090bb5cdc4.png)
#### line 124 150 162
修改原因：通过ori_model 指定最原始的model（未封装optimizer和loss的model），在 eval 阶段可以跳过计算 loss，从而规避以下错误
![ori_model_bug](https://user-images.githubusercontent.com/61997321/140016405-899ecce7-6533-43b3-b0d5-9d04a9c89700.png)
#### line 117
修改原因：在 build 阶段未定义 self.valid_metrics，导致 line188 更新 mAp 失败
![metrics_bug](https://user-images.githubusercontent.com/61997321/140016582-61ea1df8-8d59-41d7-89be-8fdb1694800b.png)

### 3. 添加 vega/metrics/mindspore/detection_metric.py
修改原因：mindspore metric 缺少 trainer.metric:coco 类， 参考 torch/detection_metric.py 稍微进行改动, 其中__call__未调用，无法完全保证功能正确
![metrics_coco_bug](https://user-images.githubusercontent.com/61997321/140016862-5e06ab59-c961-41ca-9b14-e8a215ae8746.png)

### 4. 修改 vega/metrics/mindspore/__init__.py
修改原因： 注册 train.metric:coco 类

### 5. 修改 vega/metrics/mindspore/metrics.py
#### line76 line78
修改原因：在mindspore下使用应该会输出mindspore的Tensor（无伤大雅）
#### line108
修改原因：传入的字典，里面的 value 均为 ndarray 元素，将其值转为 int or float，不然后续打印会如下所示
```
INFO worker id [1], epoch [1/1], current valid perfs [Precision/mAP: ndarray, Precision/mAP@.50IOU: ndarray, Precision/mAP@.75IOU: ndarray, Precision/mAP (small): ndarray, Precision/mAP (medium): ndarray, Precision/mAP (large): ndarray, Recall/AR@1: ndarray, Recall/AR@10: ndarray, Recall/AR@100: ndarray, Recall/AR@100 (small): ndarray, Recall/AR@100 (medium): ndarray, Recall/AR@100 (large): ndarray], best valid perfs [Precision/mAP: ndarray, Precision/mAP@.50IOU: ndarray, Precision/mAP@.75IOU: ndarray, Precision/mAP (small): ndarray, Precision/mAP (medium): ndarray, Precision/mAP (large): ndarray, Recall/AR@1: ndarray, Recall/AR@10: ndarray, Recall/AR@100: ndarray, Recall/AR@100 (small): ndarray, Recall/AR@100 (medium): ndarray, Recall/AR@100 (large): ndarray
```

### Other
#### 执行命令
```
import os
import vega
os.environ['DEVICE_ID'] = '0'
os.environ['RANK_SIZE'] = '1'
os.environ['RANK_ID'] = '0'
vega.run("./spnas_md.yml")
```
#### 数据集
COCO2017